### PR TITLE
SLC-17 Change API to coverage directory inside of API directory (not in parent)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -78,7 +78,6 @@
       "<rootDir>/src/services/*.ts",
       "<rootDir>/src/**/*controller.ts"
     ],
-    "coverageDirectory": "../coverage",
     "coveragePathIgnorePatterns": [
       "^.+app\\.module\\.ts$",
       "^.+main\\.ts$"


### PR DESCRIPTION
* Remove coverageDirectory from API jest config
* This forces the coverage output to the same
* directory as package.json (by default)