### PR TITLE
SLC-API-26 Add API endpoint - lookup and return user info

### DIFF
--- a/api/src/data/users.json
+++ b/api/src/data/users.json
@@ -1,36 +1,36 @@
 [
 	{
 		"accountId": "U9b-KVWyJkTpQR0YiPJt7U8DFqy5llDfTJZYV56-G7onXevEOMC_DiI1",
-		"lastUpdated": 1602554096282,
+		"lastUpdated": 1602826546207,
 		"masteryTotal": 83,
 		"name": "Anthony",
 		"summonerId": "hcLRomxparq_5yiMDPH-dS3iLiw4xCZhGu-pxv-uviArAiog"
 	},
 	{
 		"accountId": "Cn0MOwyHpDXOLaCqpbkwMoIs1M8r9IJnv39DOM867E1zTjE",
-		"lastUpdated": 1602554096268,
+		"lastUpdated": 1602826546193,
 		"masteryTotal": 53,
 		"name": "Nicole",
 		"summonerId": "G5tCj_5KLJajQ4V6PtbYjRlY_s3lRwY0ubNe4EM-NL3pG408"
 	},
 	{
 		"accountId": "aME0ZGruQhV8etyYYIys4vqFarj13QyvFztnwVIHImEgEgiwl7OLPsRE",
-		"lastUpdated": 1602554096270,
+		"lastUpdated": 1602826546189,
 		"masteryTotal": 27,
 		"name": "Vinny",
 		"summonerId": "Dm9zNbtMP8bqWlSsVgkPeu-ZwuRJbjKzn-BUvO1hiyXjyfC1"
 	},
 	{
 		"accountId": "Z8ufPKNP9ZpxH1YTirB3axCZKXFAgYc46rPrxRjwQHtGog",
-		"lastUpdated": 1602554096291,
+		"lastUpdated": 1602826546209,
 		"masteryTotal": 294,
 		"name": "Rob",
 		"summonerId": "ambil30qwgVvs2ud1K_z2lKxZxK1Rsuy7fqMHssNT0RX5f0"
 	},
 	{
 		"accountId": "OCamYtFbkjSq9tK5lMQ2KLCcFHFL0iwTv-KyAiJnIgylmw",
-		"lastUpdated": 1602554096240,
-		"masteryTotal": 80,
+		"lastUpdated": 1602826546204,
+		"masteryTotal": 81,
 		"name": "Keenen",
 		"summonerId": "iQf-PRosKC7dU_JY9kYk8jYVq4n9QpQytEE3TxD_nuDrDEY"
 	}

--- a/api/src/models/summoner.model.ts
+++ b/api/src/models/summoner.model.ts
@@ -1,0 +1,75 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+/**
+ * @summary Represents a summoner
+ */
+class Summoner {
+	@ApiProperty({
+		description: 'Encrypted account ID. Max length 56 characters',
+		maxLength: 56,
+	})
+	accountId: string
+
+	@ApiProperty({
+		description: 'Encrypted summoner ID. Max length 63 characters',
+		maxLength: 63,
+	})
+	id: string
+
+	@ApiProperty({
+		description: 'Summoner name',
+	})
+	name: string
+
+	@ApiProperty({
+		description: 'ID of the summoner icon associated with the summoner',
+	})
+	profileIconId: number
+
+	@ApiProperty({
+		description: 'Encrypted PUUID. Exact length of 78 characters',
+		maxLength: 78,
+		minLength: 78,
+	})
+	puuid: string
+
+	@ApiProperty({
+		description: 'Date summoner was last modified specified as epoch milliseconds. The following events will update this timestamp: summoner name change, summoner level change, or profile icon change',
+	})
+	revisionDate: number
+
+	@ApiProperty({
+		description: 'Summoner level associated with the summoner',
+	})
+	summonerLevel: number
+
+	/**
+	 * @param accountId - Encrypted account ID. Max length 56 characters
+	 * @param id - Encrypted summoner ID. Max length 63 characters
+	 * @param name - Summoner name
+	 * @param profileIconId - ID of the summoner icon associated with the summoner
+	 * @param puuid - Encrypted PUUID. Exact length of 78 characters
+	 * @param revisionDate - Date summoner was last modified specified as epoch milliseconds. The following events
+	 *   will update this timestamp: summoner name change, summoner level change, or profile icon change
+	 * @param summonerLevel - Summoner level associated with the summoner
+	 */
+	constructor(
+		accountId: string,
+		id: string,
+		name: string,
+		profileIconId: number,
+		puuid: string,
+		revisionDate: number,
+		summonerLevel: number,
+	) {
+		this.accountId = accountId
+		this.id = id
+		this.name = name
+		this.profileIconId = profileIconId
+		this.puuid = puuid
+		this.revisionDate = revisionDate
+		this.summonerLevel = summonerLevel
+	}
+}
+
+export { Summoner }

--- a/api/src/services/summoner.service.spec.ts
+++ b/api/src/services/summoner.service.spec.ts
@@ -52,10 +52,10 @@ describe('Summoner Service', () => {
 		let mockVerbose: jest.Mock
 
 		beforeEach(() => {
-			mockDebug = jest.fn((msg, ...args) => {})
-			mockError = jest.fn((msg, ...args) => {})
-			mockLog = jest.fn((msg, ...args) => {})
-			mockVerbose = jest.fn((msg, ...args) => {})
+			mockDebug = jest.fn()
+			mockError = jest.fn()
+			mockLog = jest.fn()
+			mockVerbose = jest.fn()
 
 			jest.spyOn(testModule.get(Logger), 'debug')
 				.mockImplementation(mockDebug)
@@ -98,8 +98,19 @@ describe('Summoner Service', () => {
 				expectedCountLog: 0,
 				expectedCountVerbose: 2,
 				expectedResult: null,
-				mockHttpGet: jest.fn(() => from(Promise.resolve({ status: HttpStatus.NOT_FOUND } as AxiosResponse))),
+				mockHttpGet: jest.fn(() => from(Promise.resolve({ status: HttpStatus.NOT_FOUND } as AxiosResponse<Summoner>))),
 				param: '',
+			},
+			{
+				descriptionMockedBehavior: 'request succeeds and has data',
+				expectedCountDebug: 1,
+				expectedCountError: 0,
+				expectedCountGet: 1,
+				expectedCountLog: 0,
+				expectedCountVerbose: 2,
+				expectedResult: { name: 'summ-name-1' } as Summoner,
+				mockHttpGet: jest.fn(() => from(Promise.resolve({ data: { name: 'summ-name-1' } as Summoner, status: HttpStatus.OK } as AxiosResponse<Summoner>))),
+				param: 'summ-name-1',
 			},
 		]
 		testCases_searchByName.forEach((
@@ -142,7 +153,7 @@ describe('Summoner Service', () => {
 
 						if (expectedCountGet > 0) {
 							expect(mockHttpGet).toHaveBeenLastCalledWith(
-								'https://na1.api.riotgames.com/lol/summoner/v4/summoners/by-name/',
+								`https://na1.api.riotgames.com/lol/summoner/v4/summoners/by-name/${param}`,
 								{
 									headers: {
 										'Accept-Charset': 'application/x-www-form-urlencoded; charset=UTF-8',

--- a/api/src/services/summoner.service.spec.ts
+++ b/api/src/services/summoner.service.spec.ts
@@ -19,6 +19,7 @@ type TestCase_SearchByName = {
 }
 
 describe('Summoner Service', () => {
+	const fakeAPIKey = 'some-api-key'
 	let service: SummonerService
 	let testModule: TestingModule
 
@@ -30,7 +31,7 @@ describe('Summoner Service', () => {
 				{
 					provide: ConfigService,
 					useFactory: () => ({
-						get: jest.fn().mockReturnValue('some-api-key'),
+						get: jest.fn().mockReturnValue(fakeAPIKey),
 					}),
 				},
 				SummonerService,
@@ -125,7 +126,7 @@ describe('Summoner Service', () => {
 				mockHttpGet,
 				param,
 			}) => {
-			describe(`w/ mocked HTTP Get (${descriptionMockedBehavior})`, () => {	
+			describe(`w/ mocked HTTP Get (${descriptionMockedBehavior})`, () => {
 				beforeEach(() => {
 					jest.spyOn(testModule.get(HttpService), 'get')
 						.mockImplementation(mockHttpGet)
@@ -158,7 +159,7 @@ describe('Summoner Service', () => {
 									headers: {
 										'Accept-Charset': 'application/x-www-form-urlencoded; charset=UTF-8',
 										'Accept-Language': 'en-US,en;q=0.9',
-										'X-Riot-Token': 'some-api-key',
+										'X-Riot-Token': fakeAPIKey,
 									},
 								})
 						}

--- a/api/src/services/summoner.service.spec.ts
+++ b/api/src/services/summoner.service.spec.ts
@@ -1,7 +1,8 @@
 import { Summoner } from '@models/summoner.model'
-import { HttpModule, HttpService, Logger } from '@nestjs/common'
+import { HttpModule, HttpService, HttpStatus, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
+import { AxiosResponse } from 'axios'
 import { from } from 'rxjs'
 import { SummonerService } from './summoner.service'
 
@@ -87,6 +88,17 @@ describe('Summoner Service', () => {
 				expectedCountVerbose: 2,
 				expectedResult: null,
 				mockHttpGet: jest.fn(() => from(Promise.reject(new Error('fake AJW error')))),
+				param: '',
+			},
+			{
+				descriptionMockedBehavior: 'request succeeds w/ NOT_FOUND',
+				expectedCountDebug: 2,
+				expectedCountError: 0,
+				expectedCountGet: 1,
+				expectedCountLog: 0,
+				expectedCountVerbose: 2,
+				expectedResult: null,
+				mockHttpGet: jest.fn(() => from(Promise.resolve({ status: HttpStatus.NOT_FOUND } as AxiosResponse))),
 				param: '',
 			},
 		]

--- a/api/src/services/summoner.service.spec.ts
+++ b/api/src/services/summoner.service.spec.ts
@@ -1,0 +1,149 @@
+import { Summoner } from '@models/summoner.model'
+import { HttpModule, HttpService, Logger } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { Test, TestingModule } from '@nestjs/testing'
+import { from } from 'rxjs'
+import { SummonerService } from './summoner.service'
+
+type TestCase_SearchByName = {
+	descriptionMockedBehavior: string
+	expectedCountDebug: number
+	expectedCountError: number
+	expectedCountGet: number
+	expectedCountLog: number
+	expectedCountVerbose: number
+	expectedResult: Summoner | null
+	mockHttpGet: jest.Mock
+	param: string
+}
+
+describe('Summoner Service', () => {
+	let service: SummonerService
+	let testModule: TestingModule
+
+	beforeEach(async () => {
+		testModule = await Test.createTestingModule({
+			controllers: [],
+			imports: [HttpModule],
+			providers: [
+				{
+					provide: ConfigService,
+					useFactory: () => ({
+						get: jest.fn().mockReturnValue('some-api-key'),
+					}),
+				},
+				SummonerService,
+				Logger,
+			],
+		}).compile()
+
+		service = testModule.get(SummonerService)
+	})
+
+	afterEach(async () => {
+		await testModule.close()
+	})
+
+	describe('w/ mocked logger functions [ debug, error, log, verbose ]', () => {
+		let mockDebug: jest.Mock
+		let mockError: jest.Mock
+		let mockLog: jest.Mock
+		let mockVerbose: jest.Mock
+
+		beforeEach(() => {
+			mockDebug = jest.fn((msg, ...args) => {})
+			mockError = jest.fn((msg, ...args) => {})
+			mockLog = jest.fn((msg, ...args) => {})
+			mockVerbose = jest.fn((msg, ...args) => {})
+
+			jest.spyOn(testModule.get(Logger), 'debug')
+				.mockImplementation(mockDebug)
+			jest.spyOn(testModule.get(Logger), 'error')
+				.mockImplementation(mockError)
+			jest.spyOn(testModule.get(Logger), 'log')
+				.mockImplementation(mockLog)
+			jest.spyOn(testModule.get(Logger), 'verbose')
+				.mockImplementation(mockVerbose)
+		})
+
+		afterEach(() => {
+			jest.spyOn(testModule.get(Logger), 'debug')
+				.mockRestore()
+			jest.spyOn(testModule.get(Logger), 'error')
+				.mockRestore()
+			jest.spyOn(testModule.get(Logger), 'log')
+				.mockRestore()
+			jest.spyOn(testModule.get(Logger), 'verbose')
+				.mockRestore()
+		})
+
+		const testCases_searchByName: TestCase_SearchByName[] = [
+			{
+				descriptionMockedBehavior: 'request fails',
+				expectedCountDebug: 1,
+				expectedCountError: 0,
+				expectedCountGet: 1,
+				expectedCountLog: 0,
+				expectedCountVerbose: 2,
+				expectedResult: null,
+				mockHttpGet: jest.fn(() => from(Promise.reject(new Error('fake AJW error')))),
+				param: '',
+			},
+		]
+		testCases_searchByName.forEach((
+			{
+				descriptionMockedBehavior,
+				expectedCountDebug,
+				expectedCountError,
+				expectedCountGet,
+				expectedCountLog,
+				expectedCountVerbose,
+				expectedResult,
+				mockHttpGet,
+				param,
+			}) => {
+			describe(`w/ mocked HTTP Get (${descriptionMockedBehavior})`, () => {	
+				beforeEach(() => {
+					jest.spyOn(testModule.get(HttpService), 'get')
+						.mockImplementation(mockHttpGet)
+				})
+
+				afterEach(() => {
+					jest.spyOn(testModule.get(HttpService), 'get')
+						.mockRestore()
+				})
+
+				describe('invoke searchByName()', () => {
+					let actualResult: Summoner | null
+
+					beforeEach(async () => {
+						actualResult = await service.searchByName(param)
+					})
+
+					it('invokes get(), log(), error(), debug(), verbose() correctly and returns expected result', () => {
+						expect(mockDebug).toHaveBeenCalledTimes(expectedCountDebug)
+						expect(mockError).toHaveBeenCalledTimes(expectedCountError)
+						expect(mockLog).toHaveBeenCalledTimes(expectedCountLog)
+						expect(mockVerbose).toHaveBeenCalledTimes(expectedCountVerbose)
+
+						expect(mockHttpGet).toHaveBeenCalledTimes(expectedCountGet)
+
+						if (expectedCountGet > 0) {
+							expect(mockHttpGet).toHaveBeenLastCalledWith(
+								'https://na1.api.riotgames.com/lol/summoner/v4/summoners/by-name/',
+								{
+									headers: {
+										'Accept-Charset': 'application/x-www-form-urlencoded; charset=UTF-8',
+										'Accept-Language': 'en-US,en;q=0.9',
+										'X-Riot-Token': 'some-api-key',
+									},
+								})
+						}
+
+						expect(actualResult).toEqual(expectedResult)
+					})
+				})
+			})
+		})
+	})
+})

--- a/api/src/services/summoner.service.ts
+++ b/api/src/services/summoner.service.ts
@@ -13,7 +13,7 @@ import { ENV_API_KEY, ENV_API_KEY_DEFAULT, REGION } from '../constants'
 @Injectable()
 export class SummonerService {
 	private static readonly BASE = `https://${REGION}.api.riotgames.com`
-	private static readonly ENDPOINT_SEARCH_BY_NAME = '/lol/summoner/v4/summoners/by-name'
+	private static readonly ENDPOINT_SEARCH_BY_NAME = 'lol/summoner/v4/summoners/by-name'
 
 	constructor(
 		@Inject(ConfigService)

--- a/api/src/services/summoner.service.ts
+++ b/api/src/services/summoner.service.ts
@@ -1,0 +1,64 @@
+import { Summoner } from '@models/summoner.model'
+import {
+	HttpService,
+	HttpStatus,
+	Inject,
+	Injectable,
+	Logger
+} from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { AxiosResponse } from 'axios'
+import { ENV_API_KEY, ENV_API_KEY_DEFAULT, REGION } from '../constants'
+
+@Injectable()
+export class SummonerService {
+	private static readonly BASE = `https://${REGION}.api.riotgames.com`
+	private static readonly ENDPOINT_SEARCH_BY_NAME = '/lol/summoner/v4/summoners/by-name'
+
+	constructor(
+		@Inject(ConfigService)
+		private readonly configService: ConfigService,
+		@Inject(HttpService)
+		private readonly httpService: HttpService,
+		@Inject(Logger)
+		private readonly logger: Logger,
+	) {}
+
+	/**
+	 * This method uses the Riot API to search for a Summoner by name
+	 *
+	 * @returns Promise<Summoner | null> - information about a Summoner, if found; null otherwise
+	 */
+	async searchByName(searchKey: string): Promise<Summoner | null> {
+		const ctx = ' Summoner-Svc | searchByName '
+
+		try {
+			this.logger.verbose('Grabbing riotToken...', ctx)
+	
+			const riotToken = this.configService.get<string>(ENV_API_KEY, ENV_API_KEY_DEFAULT)
+	
+			this.logger.verbose(`riotToken="${riotToken}"`, ctx)
+			this.logger.debug('About to contact Riot API...', ctx)
+	
+			const getResp: AxiosResponse<Summoner> = await this.httpService.get(
+				`${SummonerService.BASE}/${SummonerService.ENDPOINT_SEARCH_BY_NAME}/${searchKey}`,
+				{
+					headers: {
+						'Accept-Charset': 'application/x-www-form-urlencoded; charset=UTF-8',
+						'Accept-Language': 'en-US,en;q=0.9',
+						'X-Riot-Token': riotToken,
+					},
+				}
+			).toPromise()
+
+			if (getResp.status === HttpStatus.NOT_FOUND) {
+				this.logger.debug('Summoner was not found, returning null...', ctx)
+				return null
+			}
+
+			return getResp.data
+		} catch (err) {
+			return null
+		}
+	}
+}

--- a/api/src/user/user.controller.spec.ts
+++ b/api/src/user/user.controller.spec.ts
@@ -11,6 +11,7 @@ import { SummonerService } from '../services/summoner.service'
 import { UserController } from './user.controller'
 
 const toggleMockedLogger = (testModule: TestingModule, enable = true): Record<string, jest.Mock> => {
+	const logger: Logger = testModule.get(Logger)
 	let mockDebug: jest.Mock
 	let mockError: jest.Mock
 	let mockLog: jest.Mock
@@ -22,28 +23,20 @@ const toggleMockedLogger = (testModule: TestingModule, enable = true): Record<st
 		mockLog = jest.fn()
 		mockVerbose = jest.fn()
 
-		jest.spyOn(testModule.get(Logger), 'debug')
-			.mockImplementation(mockDebug)
-		jest.spyOn(testModule.get(Logger), 'error')
-			.mockImplementation(mockError)
-		jest.spyOn(testModule.get(Logger), 'log')
-			.mockImplementation(mockLog)
-		jest.spyOn(testModule.get(Logger), 'verbose')
-			.mockImplementation(mockVerbose)
+		jest.spyOn(logger, 'debug').mockImplementation(mockDebug)
+		jest.spyOn(logger, 'error').mockImplementation(mockError)
+		jest.spyOn(logger, 'log').mockImplementation(mockLog)
+		jest.spyOn(logger, 'verbose').mockImplementation(mockVerbose)
 	} else {
-		mockDebug = testModule.get(Logger).debug as jest.Mock
-		mockError = testModule.get(Logger).error as jest.Mock
-		mockLog = testModule.get(Logger).log as jest.Mock
-		mockVerbose = testModule.get(Logger).verbose as jest.Mock
+		mockDebug = logger.debug as jest.Mock
+		mockError = logger.error as jest.Mock
+		mockLog = logger.log as jest.Mock
+		mockVerbose = logger.verbose as jest.Mock
 	
-		jest.spyOn(testModule.get(Logger), 'debug')
-			.mockRestore()
-		jest.spyOn(testModule.get(Logger), 'error')
-			.mockRestore()
-		jest.spyOn(testModule.get(Logger), 'log')
-			.mockRestore()
-		jest.spyOn(testModule.get(Logger), 'verbose')
-			.mockRestore()
+		jest.spyOn(logger, 'debug').mockRestore()
+		jest.spyOn(logger, 'error').mockRestore()
+		jest.spyOn(logger, 'log').mockRestore()
+		jest.spyOn(logger, 'verbose').mockRestore()
 	}
 
 	return {

--- a/api/src/user/user.controller.spec.ts
+++ b/api/src/user/user.controller.spec.ts
@@ -1,7 +1,10 @@
+import { Summoner } from '@models/summoner.model'
 import { User } from '@models/user.model'
+// import { HttpModule, HttpService, HttpStatus, Logger } from '@nestjs/common'
 import { HttpModule, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
+// import { AxiosResponse } from 'axios'
 import childProcess from 'child_process'
 import { JsonLoaderService } from '../services/json-loader.service'
 import { SummonerService } from '../services/summoner.service'
@@ -87,6 +90,48 @@ describe('UserController', () => {
 			expect(mockLoadUsersFromFile).toHaveBeenCalledTimes(1)
 			expect(capturedError).toBeUndefined()
 			expect(resp).toEqual([])
+		})
+	})
+
+	describe('invoke searchUsers()', () => {
+		let capturedError: Error
+		// let mockHttpServiceGet: jest.Mock
+		let mockSearchByName: jest.Mock
+		let resp: Summoner | null
+
+		beforeEach(async () => {
+			// mockHttpServiceGet = jest.fn(() =>
+			// 	Promise.resolve({
+			// 		data: {} as Summoner,
+			// 		status: HttpStatus.OK,
+			// 	} as AxiosResponse<Summoner>))
+			mockSearchByName = jest.fn(() => Promise.resolve({ name: 'nameForWhichToSearch' } as Summoner))
+
+			try {
+				// jest.spyOn(testModule.get(HttpService), 'get')
+				// 	.mockImplementation(mockHttpServiceGet)
+				jest.spyOn(testModule.get(SummonerService), 'searchByName')
+					.mockImplementation(mockSearchByName)
+
+				resp = await controller.searchUsers('nameForWhichToSearch')
+			} catch (err) {
+				capturedError = err
+			}
+		})
+
+		afterEach(() => {
+			// jest.spyOn(testModule.get(HttpService), 'get')
+			// 	.mockRestore()
+			jest.spyOn(testModule.get(SummonerService), 'searchByName')
+				.mockRestore()
+		})
+
+		it('invokes SummonerService.searchByName(), does NOT throw error', () => {
+			// expect(mockHttpServiceGet).toHaveBeenCalledTimes(1)
+			expect(mockSearchByName).toHaveBeenCalledTimes(1)
+			expect(mockSearchByName).toHaveBeenLastCalledWith('nameForWhichToSearch')
+			expect(capturedError).toBeUndefined()
+			expect(resp).toEqual({ name: 'nameForWhichToSearch' } as Summoner)
 		})
 	})
 })

--- a/api/src/user/user.controller.spec.ts
+++ b/api/src/user/user.controller.spec.ts
@@ -10,6 +10,50 @@ import { JsonLoaderService } from '../services/json-loader.service'
 import { SummonerService } from '../services/summoner.service'
 import { UserController } from './user.controller'
 
+const toggleMockedLogger = (testModule: TestingModule, enable = true): Record<string, jest.Mock> => {
+	let mockDebug: jest.Mock
+	let mockError: jest.Mock
+	let mockLog: jest.Mock
+	let mockVerbose: jest.Mock
+
+	if (enable) {
+		mockDebug = jest.fn()
+		mockError = jest.fn()
+		mockLog = jest.fn()
+		mockVerbose = jest.fn()
+
+		jest.spyOn(testModule.get(Logger), 'debug')
+			.mockImplementation(mockDebug)
+		jest.spyOn(testModule.get(Logger), 'error')
+			.mockImplementation(mockError)
+		jest.spyOn(testModule.get(Logger), 'log')
+			.mockImplementation(mockLog)
+		jest.spyOn(testModule.get(Logger), 'verbose')
+			.mockImplementation(mockVerbose)
+	} else {
+		mockDebug = testModule.get(Logger).debug as jest.Mock
+		mockError = testModule.get(Logger).error as jest.Mock
+		mockLog = testModule.get(Logger).log as jest.Mock
+		mockVerbose = testModule.get(Logger).verbose as jest.Mock
+	
+		jest.spyOn(testModule.get(Logger), 'debug')
+			.mockRestore()
+		jest.spyOn(testModule.get(Logger), 'error')
+			.mockRestore()
+		jest.spyOn(testModule.get(Logger), 'log')
+			.mockRestore()
+		jest.spyOn(testModule.get(Logger), 'verbose')
+			.mockRestore()
+	}
+
+	return {
+		mockDebug,
+		mockError,
+		mockLog,
+		mockVerbose,
+	}
+}
+
 describe('UserController', () => {
 	let controller: UserController
 	let testModule: TestingModule
@@ -34,36 +78,12 @@ describe('UserController', () => {
 	})
 
 	describe('w/ mocked logger functions [ debug, error, log, verbose ]', () => {
-		let mockDebug: jest.Mock
-		let mockError: jest.Mock
-		let mockLog: jest.Mock
-		let mockVerbose: jest.Mock
-
 		beforeEach(() => {
-			mockDebug = jest.fn()
-			mockError = jest.fn()
-			mockLog = jest.fn()
-			mockVerbose = jest.fn()
-
-			jest.spyOn(testModule.get(Logger), 'debug')
-				.mockImplementation(mockDebug)
-			jest.spyOn(testModule.get(Logger), 'error')
-				.mockImplementation(mockError)
-			jest.spyOn(testModule.get(Logger), 'log')
-				.mockImplementation(mockLog)
-			jest.spyOn(testModule.get(Logger), 'verbose')
-				.mockImplementation(mockVerbose)
+			toggleMockedLogger(testModule)
 		})
 
 		afterEach(() => {
-			jest.spyOn(testModule.get(Logger), 'debug')
-				.mockRestore()
-			jest.spyOn(testModule.get(Logger), 'error')
-				.mockRestore()
-			jest.spyOn(testModule.get(Logger), 'log')
-				.mockRestore()
-			jest.spyOn(testModule.get(Logger), 'verbose')
-				.mockRestore()
+			toggleMockedLogger(testModule, false)
 		})
 
 		describe('invoke refreshUserData()', () => {

--- a/api/src/user/user.controller.spec.ts
+++ b/api/src/user/user.controller.spec.ts
@@ -1,13 +1,14 @@
 import { User } from '@models/user.model'
 import { HttpModule, Logger } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
 import childProcess from 'child_process'
 import { JsonLoaderService } from '../services/json-loader.service'
+import { SummonerService } from '../services/summoner.service'
 import { UserController } from './user.controller'
 
 describe('UserController', () => {
 	let controller: UserController
-	let mockExecFileSync: jest.Mock
 	let testModule: TestingModule
 
 	beforeEach(async () => {
@@ -15,36 +16,41 @@ describe('UserController', () => {
 			controllers: [UserController],
 			imports: [HttpModule],
 			providers: [
+				ConfigService,
 				JsonLoaderService,
+				SummonerService,
 				Logger,
 			],
 		}).compile()
 
 		controller = testModule.get(UserController)
-
-		mockExecFileSync = jest.fn()
-
-		jest.spyOn(childProcess, 'execFileSync')
-			.mockImplementation(mockExecFileSync)
 	})
 
 	afterEach(async () => {
-		jest.spyOn(childProcess, 'execFileSync')
-			.mockRestore()
-
 		await testModule.close()
 	})
 
 	describe('invoke refreshUserData()', () => {
 		let capturedError: Error
+		let mockExecFileSync: jest.Mock
 		let resp: string
 
 		beforeEach(async () => {
+			mockExecFileSync = jest.fn()
+
 			try {
+				jest.spyOn(childProcess, 'execFileSync')
+					.mockImplementation(mockExecFileSync)
+
 				resp = await controller.refreshUserData()
 			} catch (err) {
 				capturedError = err
 			}
+		})
+
+		afterEach(() => {
+			jest.spyOn(childProcess, 'execFileSync')
+				.mockRestore()
 		})
 
 		it('invokes execFileSync(), does NOT throw error', () => {
@@ -64,12 +70,17 @@ describe('UserController', () => {
 
 			try {
 				jest.spyOn(testModule.get(JsonLoaderService), 'loadUsersFromFile')
-					.mockImplementationOnce(mockLoadUsersFromFile)
+					.mockImplementation(mockLoadUsersFromFile)
 
 				resp = await controller.getUsers()
 			} catch (err) {
 				capturedError = err
 			}
+		})
+
+		afterEach(() => {
+			jest.spyOn(testModule.get(JsonLoaderService), 'loadUsersFromFile')
+				.mockRestore()
 		})
 
 		it('invokes loadUsersFromFile(), does NOT throw error', () => {

--- a/api/src/user/user.controller.ts
+++ b/api/src/user/user.controller.ts
@@ -27,6 +27,15 @@ export class UserController {
 		return this.jsonService.loadUsersFromFile()
 	}
 
+	@Get('search')
+	@HttpCode(HttpStatus.OK)
+	@Header('Cache-Control', 'none')
+	// GOAL -
+	// async searchUsers(): Promise<User> {
+	async searchUsers(): Promise<any> {
+		return {}
+	}
+
 	@Get('refresh')
 	@HttpCode(HttpStatus.OK)
 	@Header('Cache-Control', 'none')

--- a/api/src/user/user.controller.ts
+++ b/api/src/user/user.controller.ts
@@ -1,3 +1,4 @@
+import { Summoner } from '@models/summoner.model'
 import { User } from '@models/user.model'
 import {
 	Controller,
@@ -6,16 +7,19 @@ import {
 	HttpCode,
 	HttpStatus,
 	Inject,
-	Logger
+	Logger,
+	Param
 } from '@nestjs/common'
 import { execFileSync } from 'child_process'
 import { join } from 'path'
+import { SummonerService } from '../services/summoner.service'
 import { JsonLoaderService } from '../services/json-loader.service'
 
 @Controller('user')
 export class UserController {
 	constructor(
 		private readonly jsonService: JsonLoaderService,
+		private readonly summonerService: SummonerService,
 		@Inject(Logger)
 		private readonly logger: Logger
 	) { }
@@ -24,22 +28,28 @@ export class UserController {
 	@HttpCode(HttpStatus.OK)
 	@Header('Cache-Control', 'none')
 	async getUsers(): Promise<User[]> {
+		this.logger.debug('', ' User-Ctrl | getUsers ')
+
 		return this.jsonService.loadUsersFromFile()
 	}
 
 	@Get('search')
 	@HttpCode(HttpStatus.OK)
 	@Header('Cache-Control', 'none')
-	// GOAL -
-	// async searchUsers(): Promise<User> {
-	async searchUsers(): Promise<any> {
-		return {}
+	async searchUsers(
+		@Param('searchKey') searchKey: string,
+	): Promise<Summoner | null> {
+		this.logger.debug('', ' User-Ctrl | searchUsers ')
+
+		return this.summonerService.searchByName(searchKey)
 	}
 
 	@Get('refresh')
 	@HttpCode(HttpStatus.OK)
 	@Header('Cache-Control', 'none')
 	async refreshUserData(): Promise<string> {
+		this.logger.debug('', ' User-Ctrl | refreshUserData ')
+
 		const dirContainingPackage = join(__dirname, '..', '..')
 		this.logger.warn(
 			`About to execute script in dir "${dirContainingPackage}" ...`,

--- a/api/src/user/user.module.ts
+++ b/api/src/user/user.module.ts
@@ -1,7 +1,7 @@
 import { HttpModule, Logger, Module } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
+import { SummonerService } from '../services/summoner.service'
 import { JsonLoaderService } from '../services/json-loader.service'
-// import { MatchlistService } from '../services/matchlist.service'
 import { UserController } from './user.controller'
 
 @Module({
@@ -10,7 +10,7 @@ import { UserController } from './user.controller'
 	providers: [
 		ConfigService,
 		JsonLoaderService,
-		// MatchlistService,
+		SummonerService,
 		Logger,
 	],
 })


### PR DESCRIPTION
This changelist also includes a new technique for mocking loggers in unit tests; it can be viewed in `api/src/user/user.controller.spec.ts`